### PR TITLE
Fix invalid US-ASCII character error

### DIFF
--- a/_sass/hamburgers/hamburgers.scss
+++ b/_sass/hamburgers/hamburgers.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*!
  * Hamburgers
  * @description Tasty CSS-animated hamburgers


### PR DESCRIPTION
This patch fixes _Invalid US-ASCII character \"\xE2\"_ when importing hamburger.scss into other sass projects. 

Please review. 
Thanks.
